### PR TITLE
:wrench: Create xcscheme file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,7 +62,7 @@ playground.xcworkspace
 # Carthage
 #
 # Add this line if you want to avoid checking in source code from Carthage dependencies.
-# Carthage/Checkouts
+Carthage/Checkouts
 
 Carthage/Build/
 

--- a/AKProcessIndicator.xcodeproj/xcshareddata/xcschemes/AKProcessIndicator.xcscheme
+++ b/AKProcessIndicator.xcodeproj/xcshareddata/xcschemes/AKProcessIndicator.xcscheme
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1140"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "F4A1A6B12470A5F5006DD470"
+               BuildableName = "AKProcessIndicator.framework"
+               BlueprintName = "AKProcessIndicator"
+               ReferencedContainer = "container:AKProcessIndicator.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "F4A1A6BA2470A5F5006DD470"
+               BuildableName = "AKProcessIndicatorTests.xctest"
+               BlueprintName = "AKProcessIndicatorTests"
+               ReferencedContainer = "container:AKProcessIndicator.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "F4A1A6B12470A5F5006DD470"
+            BuildableName = "AKProcessIndicator.framework"
+            BlueprintName = "AKProcessIndicator"
+            ReferencedContainer = "container:AKProcessIndicator.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/AKProcessIndicator.xcodeproj/xcshareddata/xcschemes/AKProcessIndicatorExample.xcscheme
+++ b/AKProcessIndicator.xcodeproj/xcshareddata/xcschemes/AKProcessIndicatorExample.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1140"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "F4A1A6D72470AB3D006DD470"
+               BuildableName = "AKProcessIndicatorExample.app"
+               BlueprintName = "AKProcessIndicatorExample"
+               ReferencedContainer = "container:AKProcessIndicator.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "F4A1A6D72470AB3D006DD470"
+            BuildableName = "AKProcessIndicatorExample.app"
+            BlueprintName = "AKProcessIndicatorExample"
+            ReferencedContainer = "container:AKProcessIndicator.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "F4A1A6D72470AB3D006DD470"
+            BuildableName = "AKProcessIndicatorExample.app"
+            BlueprintName = "AKProcessIndicatorExample"
+            ReferencedContainer = "container:AKProcessIndicator.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Cartfile
+++ b/Cartfile
@@ -1,0 +1,1 @@
+github "AkkeyLab/AKProcessIndicator"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,0 +1,1 @@
+github "AkkeyLab/AKProcessIndicator" "0.0.1"


### PR DESCRIPTION
```
12:51:08  akkeylab@AKIOs-Mac-Pro  ~/Dev…ent/AKProcessIndicator   master 0.0.1 ?  carthage update --platform iOS --no-use-binaries
*** Fetching AKProcessIndicator
*** Checking out AKProcessIndicator at "0.0.1"
*** xcodebuild output can be found in /var/folders/pd/my3ty6b14q36tjltyp7ss3v00000gn/T/carthage-xcodebuild.mBjo02.log
*** Skipped building AKProcessIndicator due to the error:
Dependency "AKProcessIndicator" has no shared framework schemes for any of the platforms: iOS

If you believe this to be an error, please file an issue with the maintainers at https://github.com/AkkeyLab/AKProcessIndicator/issues/new
```

https://stackoverflow.com/a/35111518/12409770